### PR TITLE
Firebase

### DIFF
--- a/Wifi/src/main.cpp
+++ b/Wifi/src/main.cpp
@@ -118,7 +118,7 @@ const unsigned long DISPLAY_INTERVAL = 3000;        // 3 seconds
 const unsigned long WIFI_CHECK_INTERVAL = 5000;     // 5 seconds
 const unsigned long BUTTON_DEBOUNCE_MS = 50;        // 50ms debounce
 const unsigned long LONG_PRESS_MS = 5000;           // 5 second long press
-const unsigned long TRIPLE_PRESS_WINDOW = 2000;     // 2 second window for triple press
+const unsigned long TRIPLE_PRESS_WINDOW = 1500;     // 1.5 second window for triple press
 
 // Smart Retry Intervals (exponential backoff)
 const unsigned long RETRY_INTERVAL_1 = 3600000;     // 1 hour


### PR DESCRIPTION
This pull request refines the button press detection logic in `Wifi/src/main.cpp`, making triple press detection more immediate and short press handling more robust. The changes reduce the triple press window, detect triple presses as soon as the third press occurs, and ensure short presses are only registered after the triple press window expires. This improves the responsiveness and reliability of button actions.

**Button press detection improvements:**

* Reduced the `TRIPLE_PRESS_WINDOW` constant from 2 seconds to 1.5 seconds, making triple press detection more responsive.
* Modified logic to detect a triple press immediately upon the third button press, rather than waiting for the button release.
* Changed short press handling to delay returning a short press until after the triple press window expires, preventing accidental short press detection during triple press attempts.
* Added logic to handle delayed short press detection and reset the press count for incomplete triple presses after the window expires, improving reliability for both short and triple press actions.